### PR TITLE
deluge udpate

### DIFF
--- a/data/interfaces/default/config.html
+++ b/data/interfaces/default/config.html
@@ -317,7 +317,7 @@
                                 <input type="radio" name="torrent_downloader" id="torrent_downloader_blackhole" value="0" ${config['torrent_downloader_blackhole']}> Black Hole
                                 <input type="radio" name="torrent_downloader" id="torrent_downloader_transmission" value="1" ${config['torrent_downloader_transmission']}> Transmission
                                 <input type="radio" name="torrent_downloader" id="torrent_downloader_utorrent" value="2" ${config['torrent_downloader_utorrent']}> uTorrent (Beta)
-                                <input type="radio" name="torrent_downloader" id="torrent_downloader_deluge" value="3" ${config['torrent_downloader_deluge']}> Deluge (Beta)
+                                <input type="radio" name="torrent_downloader" id="torrent_downloader_deluge" value="3" ${config['torrent_downloader_deluge']}> Deluge
                                 <input type="radio" name="torrent_downloader" id="torrent_downloader_qbittorrent" value="4" ${config['torrent_downloader_qbittorrent']}> QBitTorrent
                             </fieldset>
                             <fieldset id="torrent_blackhole_options">
@@ -437,6 +437,11 @@
                                     <label>Deluge Label</label>
                                     <input type="text" name="deluge_label" value="${config['deluge_label']}" size="30">
                                     <small>Labels shouldn't contain spaces (requires Label plugin)</small>
+                                </div>
+                                <div class="row">
+                                    <label>Download Directory</label>
+                                    <input type="text" name="deluge_download_directory" value="${config['deluge_download_directory']}" size="30">
+                                    <small>Directory where Deluge should download to</small>
                                 </div>
                                 <div class="row">
                                     <label>Move When Completed</label>

--- a/headphones/config.py
+++ b/headphones/config.py
@@ -79,6 +79,7 @@ _CONFIG_DEFINITIONS = {
     'DELUGE_PASSWORD': (str, 'Deluge', ''),
     'DELUGE_LABEL': (str, 'Deluge', ''),
     'DELUGE_DONE_DIRECTORY': (str, 'Deluge', ''),
+    'DELUGE_DOWNLOAD_DIRECTORY': (str, 'Deluge', ''),
     'DELUGE_PAUSED': (int, 'Deluge', 0),
     'DESTINATION_DIR': (str, 'General', ''),
     'DETECT_BITRATE': (int, 'General', 0),

--- a/headphones/searcher.py
+++ b/headphones/searcher.py
@@ -943,10 +943,6 @@ def send_to_downloader(data, bestqual, album):
                     logger.error("Error sending torrent to Deluge. Are you sure it's running? Maybe the torrent already exists?")
                     return
 
-                # This pauses the torrent right after it is added
-                if headphones.CONFIG.DELUGE_PAUSED:
-                    deluge.setTorrentPause({'hash': torrentid})
-
                 # Set Label
                 if headphones.CONFIG.DELUGE_LABEL:
                     deluge.setTorrentLabel({'hash': torrentid})
@@ -955,10 +951,6 @@ def send_to_downloader(data, bestqual, album):
                 seed_ratio = get_seed_ratio(bestqual[3])
                 if seed_ratio is not None:
                     deluge.setSeedRatio({'hash': torrentid, 'ratio': seed_ratio})
-
-                # Set move-to directory
-                if headphones.CONFIG.DELUGE_DONE_DIRECTORY or headphones.CONFIG.DOWNLOAD_TORRENT_DIR:
-                    deluge.setTorrentPath({'hash': torrentid})
 
                 # Get folder name from Deluge, it's usually the torrent name
                 folder_name = deluge.getTorrentFolder({'hash': torrentid})

--- a/headphones/webserve.py
+++ b/headphones/webserve.py
@@ -1187,6 +1187,7 @@ class WebInterface(object):
             "deluge_password": headphones.CONFIG.DELUGE_PASSWORD,
             "deluge_label": headphones.CONFIG.DELUGE_LABEL,
             "deluge_done_directory": headphones.CONFIG.DELUGE_DONE_DIRECTORY,
+            "deluge_download_directory": headphones.CONFIG.DELUGE_DOWNLOAD_DIRECTORY,
             "deluge_paused": checked(headphones.CONFIG.DELUGE_PAUSED),
             "utorrent_host": headphones.CONFIG.UTORRENT_HOST,
             "utorrent_username": headphones.CONFIG.UTORRENT_USERNAME,


### PR DESCRIPTION

- Adds a "download directory" option to Deluge - this is the path where torrent data will be downloaded to. Configurable in the UI. Use in conjunction with the exsiting "move when completed" option to move the data to a new location afterwards.
- Updated deluge.py `_add_torrent_file` function to set "pause", "deluge move when completed", and new "download directory" options during the torrent creation call, rather than making multiple calls afterwards.
- Removes Deluge "beta" designation in UI